### PR TITLE
add #ifndef to io.h

### DIFF
--- a/cores/arduino/io.h
+++ b/cores/arduino/io.h
@@ -16,8 +16,13 @@
 //
 // digitalWrite
 //
-#define HIGH 1
-#define LOW 0
+#ifndef LOW
+  #define LOW 0
+#endif
+#ifndef HIGH
+  #define HIGH 1
+#endif
+
 
 //
 // public api


### PR DESCRIPTION
I receive a warning using Mriscoc's ProUI because in the proui.h there is a #define for HIGH and LOW, I fixed the warning when compiling by adding #ifndef like shown here.