### PR TITLE
refactor panic logic + systick fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ the core offers the following multiple options, which can be set in `platformio.
 | Option                                 | Description                                                                                                                                                   |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `CORE_ADC_RESOLUTION`                  | set the default resolution of ADC driver. can be `8`, `10`, or `12`. default is `10`. can be overwritten using `analogReadResolution()`                       |
-| `ENABLE_MICROS`                        | enable `micros()` function. this increases the speed of the SysTick interrupt, which may cause reduced performance. default is disabled                       |
 | `F_CPU=SYSTEM_CLOCK_FREQUENCIES.pclk1` | overwrites the `F_CPU` value. by default, `hclk` is used. refer to the HC32F460 user manual, Section 4.3, Table 4-1 for more details on the different clocks. |
 
 ## Example
@@ -43,7 +42,6 @@ the core offers the following multiple options, which can be set in `platformio.
 # ...
 build_flags =
     -D __CORE_DEBUG
-    -D ENABLE_MICROS
 ```
 
 # Arduino Core Panic

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ the core offers the following multiple options, which can be set in `platformio.
 
 ## Debug Options
 
-| Option                             | Description                                                                                   |
-| ---------------------------------- | --------------------------------------------------------------------------------------------- |
-| `__CORE_DEBUG`                     | enable debug mode. this enables additional debug output at the cost of flash space.           |
-| `__CORE_DEBUG_SHORT_FILENAMES`     | use only the filename, not the full path, in debug output. saves some flash space.            |
-| `__CORE_DEBUG_OMIT_PANIC_MESSAGES` | omit error messages in `panic()` output. saves some flash space.                              |
-| `CORE_DISABLE_FAULT_HANDLER`       | disable the core-internal fault handler. only recommended if you have your own fault handler. |
-| `HARDFAULT_EXCLUDE_CFSR_INFO`      | exclude CFSR flag parsing from fault output. saves some flash space.                          |
-| `HANG_ON_PANIC`                    | enter a infinite loop on `panic()`. default behaviour is to reset the mcu.                    |
-| `PANIC_USART<n>_TX_PIN`            | set the gpio pin that is used to transmit panic messages. `[n]` can be any value in [1,2,3,4] |
+| Option                        | Description                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `__CORE_DEBUG`                | enable debug mode. this enables additional debug output at the cost of flash space.           |
+| `__PANIC_SHORT_FILENAMES`     | use only the filename, not the full path, in debug output. saves some flash space.            |
+| `__OMIT_PANIC_MESSAGE`        | omit error messages in `panic()` output. saves some flash space.                              |
+| `CORE_DISABLE_FAULT_HANDLER`  | disable the core-internal fault handler. only recommended if you have your own fault handler. |
+| `HARDFAULT_EXCLUDE_CFSR_INFO` | exclude CFSR flag parsing from fault output. saves some flash space.                          |
+| `HANG_ON_PANIC`               | enter a infinite loop on `panic()`. default behaviour is to reset the mcu.                    |
+| `PANIC_USART<n>_TX_PIN`       | set the gpio pin that is used to transmit panic messages. `[n]` can be any value in [1,2,3,4] |
 
 ## Hardware Serial Options
 
@@ -51,14 +51,14 @@ build_flags =
 the core includes a panic mechanism that can print panic messages to one or more usart outputs. this is useful for debugging, as it allows you to see what went wrong.
 the following options are available for the core panic mechanism. they can be set in `platformio.ini` using the `build_flags` option.
 
-| Name                              | Description                                                                                                                                                                |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `__CORE_DEBUG`                    | enables arduino core debug mode. if disabled, panic (and thus faults) will be silent                                                                                       |
-| `__CORE_DEBUG_SHORT_FILENAMES`    | uses only the filename, not the full path, in panic messages                                                                                                               |
-| `__CORE_DEBUG_OMIT_PANIC_MESSAGE` | omits the panic message string from panic output. only file and line number will be printed. this reduces the output size, but you'll have to look up the message yourself |
-| `PANIC_USART[n]_TX_PIN`           | set the gpio pin that is used to transmit panic messages. `[n]` can be any value in [1,2,3,4], and up to four outputs may be defined                                       |
-| `HARDFAULT_EXCLUDE_CFSR_INFO`     | exclude CFSR flag messages from fault output. this will reduce the output size, but you'll have to look up the flag values yourself                                        |
-| `HANG_ON_PANIC`                   | enter a infinite loop on panic condition. default behaviour is to reset the mcu                                                                                            |
+| Name                          | Description                                                                                                                                                                |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `__CORE_DEBUG`                | enables arduino core debug mode. if disabled, panic (and thus faults) will be silent                                                                                       |
+| `__PANIC_SHORT_FILENAMES`     | uses only the filename, not the full path, in panic messages                                                                                                               |
+| `__OMIT_PANIC_MESSAGE`        | omits the panic message string from panic output. only file and line number will be printed. this reduces the output size, but you'll have to look up the message yourself |
+| `PANIC_USART[n]_TX_PIN`       | set the gpio pin that is used to transmit panic messages. `[n]` can be any value in [1,2,3,4], and up to four outputs may be defined                                       |
+| `HARDFAULT_EXCLUDE_CFSR_INFO` | exclude CFSR flag messages from fault output. this will reduce the output size, but you'll have to look up the flag values yourself                                        |
+| `HANG_ON_PANIC`               | enter a infinite loop on panic condition. default behaviour is to reset the mcu                                                                                            |
 
 ```ini
 build_flags =

--- a/cores/arduino/core_checks.c
+++ b/cores/arduino/core_checks.c
@@ -3,18 +3,27 @@
 #ifdef __CORE_DEBUG
 #warning "'__CORE_DEBUG' is defined, HC32 Arduino Core Debug is Enabled"
 
-#ifdef __CORE_DEBUG_SHORT_FILENAMES
-#warning "'__CORE_DEBUG_SHORT_FILENAMES' is defined, short filenames are used in debug output"
+#if !ENABLE_PANIC_HANDLER
+#warning "panic handler is disabled, but __CORE_DEBUG mode is enabled! panic output will not be available"
+#endif
+#endif // __CORE_DEBUG
+
+#if PANIC_ENABLE
+#if defined(PANIC_USART1_TX_PIN) || defined(PANIC_USART2_TX_PIN) || defined(PANIC_USART3_TX_PIN) || defined(PANIC_USART3_TX_PIN)
+#warning "PANIC_ENABLE defined alongside PANIC_USARTn_TX_PIN. please disable one of them"
+#endif
+#endif // PANIC_ENABLE
+
+#if ENABLE_PANIC_HANDLER
+#ifdef __PANIC_SHORT_FILENAMES
+#warning "'__PANIC_SHORT_FILENAMES' is defined, short filenames are used in debug output"
 #endif
 
-#ifdef __CORE_DEBUG_OMIT_PANIC_MESSAGE
-#warning "'__CORE_DEBUG_OMIT_PANIC_MESSAGE' is defined, panic message is omitted"
+#ifdef __OMIT_PANIC_MESSAGE
+#warning "'__OMIT_PANIC_MESSAGE' is defined, panic message is omitted"
 #endif
-#endif
+#endif // ENABLE_PANIC_HANDLER
 
-#if !defined(__CORE_DEBUG) && PANIC_PRINT_ENABLED
-#warning "panic output is enabled, but __CORE_DEBUG mode is disabled! panic output will not be available"
-#endif
 
 #ifdef CORE_DISABLE_FAULT_HANDLER
 #warning "'CORE_DISABLE_FAULT_HANDLER' is defined, core-internal fault handler is disabled"

--- a/cores/arduino/core_checks.c
+++ b/cores/arduino/core_checks.c
@@ -24,7 +24,10 @@
 #endif
 #endif // ENABLE_PANIC_HANDLER
 
-
 #ifdef CORE_DISABLE_FAULT_HANDLER
 #warning "'CORE_DISABLE_FAULT_HANDLER' is defined, core-internal fault handler is disabled"
+#endif
+
+#ifdef ENABLE_MICROS
+#warning "ENABLE_MICROS is deprecated. micros() is always available"
 #endif

--- a/cores/arduino/core_hooks.h
+++ b/cores/arduino/core_hooks.h
@@ -71,38 +71,6 @@ extern "C"
      * 7. call power_mode_update_post()
      */
     DEF_HOOK(sysclock_init);
-
-    /**
-     * hook called before panic_begin() is executed
-     *
-     * @note panic_printf() is not available at this point
-     * @note code in this hook should avoid creating another panic
-     * @note code in this hook should assume the system to be in a unstable state
-     * @note this hook may be called from a IRQ context, so keep it short and sweet
-     */
-    DEF_HOOK(panic_begin_pre);
-
-    /**
-     * hook called after panic_begin() was executed
-     *
-     * @note panic_printf() is available at this point
-     * @note code in this hook should avoid creating another panic
-     * @note code in this hook should assume the system to be in a unstable state
-     * @note this hook may be called from a IRQ context, so keep it short and sweet
-     */
-    DEF_HOOK(panic_begin_post);
-
-    /**
-     * hook called before panic_end() is executed
-     *
-     * @note panic_printf() is available at this point
-     * @note code in this hook should avoid creating another panic
-     * @note code in this hook should assume the system to be in a unstable state
-     * @note this hook may be called from a IRQ context, so keep it short and sweet
-     * @note the system will stop execution after this hook returns, either by reset or hang
-     */
-    DEF_HOOK(panic_end);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cores/arduino/delay.h
+++ b/cores/arduino/delay.h
@@ -40,7 +40,6 @@ extern "C"
     return systick_millis();
   }
 
-#ifdef ENABLE_MICROS
   /**
    * \brief Returns the number of microseconds since the Arduino board began running the current program.
    *
@@ -55,7 +54,6 @@ extern "C"
   {
     return systick_micros();
   }
-#endif
 
   /**
    * \brief Pauses the program for the amount of time (in miliseconds) specified as parameter.

--- a/cores/arduino/drivers/panic/panic.h
+++ b/cores/arduino/drivers/panic/panic.h
@@ -63,12 +63,11 @@ extern "C"
 
   /**
    * @brief core panic handler
-   * @param message message to print before panicing. may be set to NULL to
-   * omit message
+   * @param message message to print before panicing. use a empty string to omit
    * @note automatically adds file and line number to message
    */
   #ifdef __OMIT_PANIC_MESSAGE
-    #define panic(msg) _panic(PANIC_FILE_NAME "l" PANIC_LINE_NUMBER_STR, NULL)
+    #define panic(msg) _panic(PANIC_FILE_NAME "l" PANIC_LINE_NUMBER_STR)
   #else
     #define panic(msg) _panic("[" PANIC_FILE_NAME " l" PANIC_LINE_NUMBER_STR "]" msg)
   #endif

--- a/cores/arduino/drivers/panic/panic.h
+++ b/cores/arduino/drivers/panic/panic.h
@@ -1,110 +1,78 @@
 #pragma once
+#include "panic_api.h"
 #include <stdlib.h>
 
-// only enable panic print if at least one output is defined
-#define PANIC_PRINT_ENABLED          \
-    (defined(PANIC_USART1_TX_PIN) || \
-     defined(PANIC_USART2_TX_PIN) || \
-     defined(PANIC_USART3_TX_PIN) || \
-     defined(PANIC_USART4_TX_PIN))
+// determine if at least one panic output is defined
+#define PANIC_OUTPUT_AVAILABLE                                                                                         \
+  (defined(PANIC_USART1_TX_PIN) || defined(PANIC_USART2_TX_PIN) || defined(PANIC_USART3_TX_PIN) ||                     \
+   defined(PANIC_USART4_TX_PIN))
 
-/**
- * cases:
- * !__CORE_DEBUG + !PANIC_PRINT_ENABLED : all stubbed
- * !__CORE_DEBUG +  PANIC_PRINT_ENABLED : all stubbed
- *  __CORE_DEBUG + !PANIC_PRINT_ENABLED : panic_begin() and panic_printf() are stubbed, panic() calls panic_end(), msg is ignored
- *  __CORE_DEBUG +  PANIC_PRINT_ENABLED : all implemented
- */
+// determine if panic handler should be active:
+// - either manually enabled
+// - or panic output is available
+#define ENABLE_PANIC_HANDLER (defined(PANIC_ENABLE) || PANIC_OUTPUT_AVAILABLE)
 
-#ifdef __cplusplus
+#if ENABLE_PANIC_HANDLER
+
+  // control printf buffer size
+  #ifndef PANIC_PRINTF_BUFFER_SIZE
+    #define PANIC_PRINTF_BUFFER_SIZE 256
+  #endif
+
+  // panic usart baud rate
+  #ifndef PANIC_USART_BAUDRATE
+    #define PANIC_USART_BAUDRATE 115200
+  #endif
+
+  #ifdef __cplusplus
 extern "C"
 {
-#endif
+  #endif
+  /**
+   * @brief print message to panic output, if enabled
+   * @param fmt format string
+   * @param ... format arguments
+   * @return number of characters printed
+   */
+  size_t panic_printf(const char *fmt, ...);
 
-#ifdef __CORE_DEBUG
+  /**
+   * @brief internal panic handler
+   * @param message message to print before panicing. may be set to NULL to omit
+   * message
+   */
+  void _panic(const char *message);
 
-    /**
-     * @brief finalize panic, halt or reset MCU
-     * @note this function never returns
-     */
-    __attribute__((noreturn)) void panic_end(void);
+  #ifdef __cplusplus
+}
+  #endif
 
-#ifdef PANIC_PRINT_ENABLED
-    // add full implementation of panic_begin(), panic_printf(), and panic()
-
-    /**
-     * @brief initialize panic output, if enabled
-     */
-    void panic_begin(void);
-
-    /**
-     * @brief print message to panic output, if enabled
-     * @param fmt format string
-     * @param ... format arguments
-     * @return number of characters printed
-     * @note this function is only available if panic output is enabled and panic_begin() was called
-     * @note maximum number of characters printed is 256
-     */
-    size_t panic_printf(const char *fmt, ...);
-
-    /**
-     * @brief internal panic handler
-     * @param message message to print before panicing. may be set to NULL to omit message
-     */
-    inline void _panic(const char *message)
-    {
-        if (message != NULL)
-        {
-            panic_begin();
-            panic_printf(message);
-        }
-
-        panic_end();
-    }
-
-    // define file name macro for panic() to use
-    #if defined(__CORE_DEBUG_SHORT_FILENAMES) && defined(__SOURCE_FILE_NAME__) 
+  // define file name macro for panic() to use
+  #if defined(__PANIC_SHORT_FILENAMES) && defined(__SOURCE_FILE_NAME__)
     #define PANIC_FILE_NAME __SOURCE_FILE_NAME__ // only filename
-    #else
+  #else
     // no short filenames, or __SOURCE_FILE_NAME__ not available
-    #if defined(__CORE_DEBUG_SHORT_FILENAMES)
-    #warning "__CORE_DEBUG_SHORT_FILENAMES is defined, but __SOURCE_FILE_NAME__ is not available."
+    #if defined(__PANIC_SHORT_FILENAMES)
+      #warning "__PANIC_SHORT_FILENAMES is defined, but __SOURCE_FILE_NAME__ is not available."
     #endif
 
     #define PANIC_FILE_NAME __FILE__
-    #endif
+  #endif
 
-    #define PANIC_LINE_NUMBER_STR STRINGIFY(__LINE__)
+  #define PANIC_LINE_NUMBER_STR STRINGIFY(__LINE__)
 
-    /**
-     * @brief core panic handler
-     * @param message message to print before panicing. may be set to NULL to omit message
-     * @note automatically adds file and line number to message
-     */
-    #ifdef __CORE_DEBUG_OMIT_PANIC_MESSAGE
-    #define panic(msg) _panic(PANIC_FILE_NAME "l" PANIC_LINE_NUMBER_STR)
-    #else
-    #define panic(msg) _panic("[" PANIC_FILE_NAME " l" PANIC_LINE_NUMBER_STR "]"  msg)
-    #endif
-
-#else // !PANIC_PRINT_ENABLED
-    // if panic print is not enabled, stub panic_begin() and panic_printf()
-    // and redirect panic() to panic_end()
-
-    #define panic_begin()
-    #define panic_printf(fmt, ...)
-    #define panic(msg) panic_end()
-
-#endif // PANIC_PRINT_ENABLED
-#else  // !__CORE_DEBUG
-    // if core is not in debug mode, stub all panic functions
-
-    #define panic_begin()
-    #define panic_printf(fmt, ...)
-    #define panic_end()
-    #define panic(msg)
-#endif // __CORE_DEBUG
-
-#ifdef __cplusplus
-}
-#endif
+  /**
+   * @brief core panic handler
+   * @param message message to print before panicing. may be set to NULL to
+   * omit message
+   * @note automatically adds file and line number to message
+   */
+  #ifdef __OMIT_PANIC_MESSAGE
+    #define panic(msg) _panic(PANIC_FILE_NAME "l" PANIC_LINE_NUMBER_STR, NULL)
+  #else
+    #define panic(msg) _panic("[" PANIC_FILE_NAME " l" PANIC_LINE_NUMBER_STR "]" msg)
+  #endif
+#else // !ENABLE_PANIC_HANDLER
+  #define panic_printf(fmt, ...)
+  #define panic(msg)
+#endif // ENABLE_PANIC_HANDLER

--- a/cores/arduino/drivers/panic/panic_api.h
+++ b/cores/arduino/drivers/panic/panic_api.h
@@ -1,0 +1,30 @@
+/**
+ * user-overridable panic handler api
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  /**
+   * @brief prepare use of panic_puts()
+   */
+  void panic_begin(void);
+
+  /**
+   * @brief print string to panic output
+   * @param str string to print
+   */
+  void panic_puts(const char *str);
+
+  /**
+   * @brief finalize panic, halt or reset MCU
+   * @note this function must not return
+   */
+  __attribute__((noreturn)) void panic_end(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/cores/arduino/drivers/sysclock/sysclock.cpp
+++ b/cores/arduino/drivers/sysclock/sysclock.cpp
@@ -15,4 +15,7 @@ void update_system_clock_frequencies()
     SYSTEM_CLOCK_FREQUENCIES.pclk3 = clkFreq.pclk3Freq;
     SYSTEM_CLOCK_FREQUENCIES.pclk4 = clkFreq.pclk4Freq;
     SYSTEM_CLOCK_FREQUENCIES.exclk = clkFreq.exckFreq;
+
+    // update SystemCoreClock of DDL
+    SystemCoreClock = SYSTEM_CLOCK_FREQUENCIES.system;
 }

--- a/cores/arduino/drivers/sysclock/systick.cpp
+++ b/cores/arduino/drivers/sysclock/systick.cpp
@@ -1,33 +1,52 @@
 #include "systick.h"
 #include <hc32_ddl.h>
 
-volatile uint32_t uptime = 0;
+/**
+ * @brief system uptime counter, incremented by systick interrupt every 1ms
+ */
+volatile uint32_t ticks_ms = 0;
 
-extern "C" void SysTick_IrqHandler(void)
+extern "C" void SysTick_Handler(void)
 {
-    // uptime++;
-    __sync_fetch_and_add(&uptime, 1);
+  __sync_fetch_and_add(&ticks_ms, 1);
 }
 
 void systick_init()
 {
-    stc_clk_freq_t clkFreq;
-    CLK_GetClockFreq(&clkFreq);
-    SysTick_Config(clkFreq.sysclkFreq / TICKS_PER_SECOND);
+  stc_clk_freq_t clkFreq;
+  CLK_GetClockFreq(&clkFreq);
+  SysTick_Config(clkFreq.sysclkFreq / 1000); // tick every 1 ms
 }
 
 uint32_t systick_millis()
 {
-#ifdef ENABLE_MICROS
-    return uptime / 1000;
-#else
-    return uptime;
-#endif
+  return ticks_ms;
 }
 
-#ifdef ENABLE_MICROS
 uint32_t systick_micros()
 {
-    return uptime;
+  // based on implementation by STM32duino
+  // https://github.com/stm32duino/Arduino_Core_STM32/blob/586319c6c2cee268747c8826d93e84b26d1549fd/libraries/SrcWrapper/src/stm32/clock.c#L29
+
+  // read systick counter value and millis counter value
+  uint32_t ms = ticks_ms;
+  volatile uint32_t ticks = SysTick->VAL;
+
+  // and again
+  uint32_t ms2 = ticks_ms;
+  volatile uint32_t ticks2 = SysTick->VAL;
+
+  // if ms != ms2, then a systick occurred between the two reads
+  // and we must use ms2 and ticks2
+  if (ms != ms2)
+  {
+    ms = ms2;
+    ticks = ticks2;
+  }
+
+  // get ticks per ms
+  const uint32_t ticks_per_ms = SysTick->LOAD + 1;
+
+  // calculate microseconds
+  return (ms * 1000) + (((ticks_per_ms - ticks) * 1000) / ticks_per_ms);
 }
-#endif

--- a/cores/arduino/drivers/sysclock/systick.h
+++ b/cores/arduino/drivers/sysclock/systick.h
@@ -1,16 +1,6 @@
 #pragma once
 #include <stdint.h>
 
-// set systick to only millisecond resolution if micros are not required
-#ifdef ENABLE_MICROS
-#define TICKS_PER_SECOND 1000000ul
-#else
-#define TICKS_PER_SECOND 1000ul
-#endif
-
 void systick_init();
 uint32_t systick_millis();
-
-#ifdef ENABLE_MICROS
 uint32_t systick_micros();
-#endif


### PR DESCRIPTION
minor refactor of panic logic, to allow for custom panic output handlers.

also includes fixes for systick (millis() and micros())