### PR TITLE
feat: `Usart` clkdiv auto-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,25 @@ the core offers the following multiple options, which can be set in `platformio.
 
 ## Hardware Serial Options
 
-| Option                   | Description                                                          |
-| ------------------------ | -------------------------------------------------------------------- |
-| `SERIAL_BUFFER_SIZE`     | set the size of both the RX and TX buffer. default value is `64`     |
-| `SERIAL_TX_BUFFER_SIZE`  | set the size of the TX buffer. default value is `SERIAL_BUFFER_SIZE` |
-| `SERIAL_RX_BUFFER_SIZE`  | set the size of the RX buffer. default value is `SERIAL_BUFFER_SIZE` |
-| `DISABLE_SERIAL_GLOBALS` | disable `Serial<n>` global variables.                                |
+| Option                        | Description                                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| `SERIAL_BUFFER_SIZE`          | set the size of both the RX and TX buffer. default value is `64`                    |
+| `SERIAL_TX_BUFFER_SIZE`       | set the size of the TX buffer. default value is `SERIAL_BUFFER_SIZE`                |
+| `SERIAL_RX_BUFFER_SIZE`       | set the size of the RX buffer. default value is `SERIAL_BUFFER_SIZE`                |
+| `DISABLE_SERIAL_GLOBALS`      | disable `Serial<n>` global variables.                                               |
+| `USART_AUTO_CLKDIV_OS_CONFIG` | enable automatic clock divider and oversampling configuration in the `Usart` driver |
+
+### `USART_AUTO_CLKDIV_OS_CONFIG` Option
+
+when defining the `USART_AUTO_CLKDIV_OS_CONFIG` option, the `Usart` driver will automatically configure the clock divider and oversampling settings based on the baudrate and the system clock frequency in such a way that the error to the actually achieved baudrate is minimized.
+this decreases the chance of communication errors due to a mismatch between the configured and the actual baudrate, at the cost of about 560 bytes of flash space.
+
+not enabling this option may limit the values that can be used for the baudrate when using the 'traditional' `Usart::begin()` functions.
+when using `Usart::begin(uint32_t baud, const stc_usart_uart_init_t *config)`, this option is not required, as the clock divider and oversampling settings can be set manually.
+
+> [!NOTE]
+> this option is opt-in to keep backwards compatibility.
+> it is recommended to enable this option if you can afford the flash space.
 
 ## Miscellanous Options
 

--- a/cores/arduino/drivers/usart/Usart.cpp
+++ b/cores/arduino/drivers/usart/Usart.cpp
@@ -78,6 +78,8 @@ inline void usart_irq_resign(usart_interrupt_config_t &irq, const char *name)
 #define CLKDIV_OS_DEBUG_PRINTF(fmt, ...)
 #endif
 
+#include "usart_util.h"
+
 /**
  * @brief calculate the real baudrate that will be achieved with the given parameters
  * @param usartClkDiv the clock divider used for the USART peripheral
@@ -114,14 +116,7 @@ float calculateRealBaudrate(uint32_t usartClkDiv, uint8_t over8, uint32_t target
         return -1.0f;
     }
 
-    // calculate the baudrate realized with the calculated dividers
-    if (useFractionalDivider) {
-        // calculation with fractional divider, see ref. manual page 621, Table 25-10
-        return ((float)usartBaseClock * (128.0f + (float)DIV_fraction)) / (8.0f * (2.0f - (float)over8) * ((float)DIV_integer + 1.0f) * 256.0f);
-    } else {
-        // calculate without fractional divider, see ref. manual page 621, Table 25-9
-        return (float)usartBaseClock / (8.0f * (2.0f - (float)over8) * ((float)DIV_integer + 1.0f));
-    }
+    return calculateBaudrate(usartBaseClock, DIV_integer, DIV_fraction, over8, useFractionalDivider);
 }
 
 /**

--- a/cores/arduino/drivers/usart/Usart.cpp
+++ b/cores/arduino/drivers/usart/Usart.cpp
@@ -297,7 +297,7 @@ void Usart::begin(uint32_t baud, uint16_t config)
     begin(baud, &usartConfig);
 }
 
-void Usart::begin(uint32_t baud, const stc_usart_uart_init_t *config)
+void Usart::begin(uint32_t baud, const stc_usart_uart_init_t *config, const bool rxNoiseFilter)
 {
     // clear rx and tx buffers
     this->rxBuffer->clear();
@@ -313,6 +313,9 @@ void Usart::begin(uint32_t baud, const stc_usart_uart_init_t *config)
     // initialize usart peripheral and set baud rate
     USART_UART_Init(this->config->peripheral.register_base, config);
     SetUartBaudrate(this->config->peripheral.register_base, baud);
+
+    // set noise filtering on RX line
+    USART_FuncCmd(this->config->peripheral.register_base, UsartNoiseFilter, rxNoiseFilter ? Enable : Disable);
 
     // setup usart interrupts
     usart_irq_register(this->config->interrupts.rx_data_available, "usart rx data available");

--- a/cores/arduino/drivers/usart/Usart.h
+++ b/cores/arduino/drivers/usart/Usart.h
@@ -35,7 +35,7 @@ public:
   Usart(struct usart_config_t *config, gpio_pin_t tx_pin, gpio_pin_t rx_pin);
   void begin(uint32_t baud);
   void begin(uint32_t baud, uint16_t config);
-  void begin(uint32_t baud, const stc_usart_uart_init_t *config);
+  void begin(uint32_t baud, const stc_usart_uart_init_t *config, const bool rxNoiseFilter = true);
   void end();
   int available();
   int availableForWrite();

--- a/cores/arduino/drivers/usart/usart_util.h
+++ b/cores/arduino/drivers/usart/usart_util.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <stdint.h>
+
+/**
+ * @brief calculate the baudrate realized with the given configuration
+ * @param usartBaseClock the base clock of the USART peripheral (PCLK1 / pre-divider set by USART_PR.PSC)
+ * @param DIV_integer the integer part of the baudrate divider (USART_BRR.DIV_Integer)
+ * @param DIV_fraction the fractional part of the baudrate divider (USART_BRR.DIV_Fraction)
+ * @param over8 the oversampling mode (0: 16-bit, 1: 8-bit; USART_CR1.OVER8)
+ * @param useFractionalDivider true if the fractional divider is used, false if not (USART_CR1.FBME)
+ * @return the baudrate realized with the given configuration
+ */
+inline float calculateBaudrate(uint32_t usartBaseClock, uint32_t DIV_integer, uint32_t DIV_fraction, uint8_t over8, bool useFractionalDivider);
+{
+    // calculate the baudrate realized with the calculated dividers
+    if (useFractionalDivider) {
+        // calculation with fractional divider, see ref. manual page 621, Table 25-10
+        return ((float)usartBaseClock * (128.0f + (float)DIV_fraction)) / (8.0f * (2.0f - (float)over8) * ((float)DIV_integer + 1.0f) * 256.0f);
+    } else {
+        // calculate without fractional divider, see ref. manual page 621, Table 25-9
+        return (float)usartBaseClock / (8.0f * (2.0f - (float)over8) * ((float)DIV_integer + 1.0f));
+    }
+}

--- a/tools/platformio/platformio-build-arduino.py
+++ b/tools/platformio/platformio-build-arduino.py
@@ -31,9 +31,27 @@ if not board_variant:
 VARIANT_DIR = join(FRAMEWORK_DIR, "variants", board_variant)
 assert isdir(VARIANT_DIR)
 
+# app_config.h is a optional header file that is included via the command line in all source files
+# it can be used to define custom configuration options for the application, as a replacement for the build_flags option
+# it can be set in platformio.ini using the 'app_config' option
+# it accepts a relative path to the file, which is resolved relative to the project root
+app_config_path = board.get("build.app_config", "app_config.h")
+app_config_path = join(env.subst("$PROJECT_DIR"), app_config_path)
+if not isfile(app_config_path):
+    app_config_path = None
 
 # setup compile environment
 env.Append(
+    # C compiler options
+    CFLAGS=[
+        f"-include{app_config_path}" if app_config_path else "",
+    ],
+
+    # C++ compiler options
+    CXXFLAGS=[
+        f"-include{app_config_path}" if app_config_path else "",
+    ],
+
     # c/c++ defines
     CPPDEFINES=[
         ("ARDUINO", 100),


### PR DESCRIPTION
this PR adds clock divider and oversampling auto configuration to the `Usart` driver.

## The Problem

currently, the `Usart` driver uses a fixed clock divider of 1 and 8x oversampling. 
due to limitations in the usart peripheral baud rate generator, this configuration may cause sub-optimal internal baud rate generation.

given a PCLK1 clock of 50MHz and a target baud rate of 115200, the actual baud rate would be closer to ~114995 baud.
using a different configuration (clkdiv=4 and 16x oversampling) this error can be minimized.

as another example, with the current configuration baud rates <= 19200 baud are not possible.

## Solution

to solve this limitation, an automatic configuration of the clock divider and oversampling setting are added. 
this new function can be enabled using the `USART_AUTO_CLKDIV_OS_CONFIG` define.

at runtime, the algorithm calculates the actually achived baud rate according to the formulars given in the HC32F460 reference manual (ref 1.5, page 621, Table 25-9 and Table 25-10) for every clock divider and oversampling setting.
it then selects a configuration such that the error between target and achived baud rate is minimal.

in a real-world application (Marlin host-print with Octoprint), the serial error rate was reduced to below 0,4%.





![25-9](https://github.com/shadow578/framework-arduino-hc32f46x/assets/52449218/27d897f8-063f-4dae-8006-24766547d169) | ![25-10](https://github.com/shadow578/framework-arduino-hc32f46x/assets/52449218/cddc67cf-6741-4eb6-87e1-cac2c1988161)
-|-
excerpt of Table 25-9 | excerpt of Table 25-10





