### PR TITLE
feat: Arduino core version macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ board_build.app_config = src/my_app_config.h
 # ...
 ```
 
+# Checking the Arduino Core Version
+
+the current version of the arduino core can be accessed using the `ARDUINO_CORE_MAJOR`, `ARDUINO_CORE_MINOR`, and `ARDUINO_CORE_PATCH` macros.
+Additionally, the helper macros `GET_VERSION_INT(major, minor, patch)` and `ARDUINO_CORE_VERSION_INT` are available in `core_util.h`.
+
+example:
+
+```cpp
+#include <core_util.h>
+
+#if ARDUINO_CORE_VERSION_INT < GET_VERSION_INT(1, 0, 0)
+  #error "expected Arduino core >= 1.0.0"
+#endif
+```
+
 # Credits
 
 This project could not have been possible without the following projects:

--- a/cores/arduino/core_checks.c
+++ b/cores/arduino/core_checks.c
@@ -1,4 +1,5 @@
 #include "drivers/panic/panic.h"
+#include "core_util.h"
 
 #ifdef __CORE_DEBUG
 #warning "'__CORE_DEBUG' is defined, HC32 Arduino Core Debug is Enabled"
@@ -30,4 +31,12 @@
 
 #ifdef ENABLE_MICROS
 #warning "ENABLE_MICROS is deprecated. micros() is always available"
+#endif
+
+#if !defined(ARDUINO_CORE_MAJOR) || !defined(ARDUINO_CORE_MINOR) || !defined(ARDUINO_CORE_PATCH)
+#error "ARDUINO_CORE_MAJOR, ARDUINO_CORE_MINOR, ARDUINO_CORE_PATCH must be defined by the builder"
+#endif
+
+#if ARDUINO_CORE_VERSION_INT < GET_VERSION_INT(1, 0, 0)
+#error "expected ARDUINO_CORE_VERSION_INT >= 1.0.0"
 #endif

--- a/cores/arduino/core_util.h
+++ b/cores/arduino/core_util.h
@@ -4,3 +4,6 @@
 #define STRINGIFY_DETAIL(x) #x
 #define STRINGIFY(x) STRINGIFY_DETAIL(x)
 #endif
+
+#define GET_VERSION_INT(major, minor, patch) ((major * 100000) + (minor * 1000) + patch)
+#define ARDUINO_CORE_VERSION_INT GET_VERSION_INT(ARDUINO_CORE_MAJOR, ARDUINO_CORE_MINOR, ARDUINO_CORE_PATCH)


### PR DESCRIPTION
the current version of the arduino core can be accessed using the `ARDUINO_CORE_MAJOR`, `ARDUINO_CORE_MINOR`, and `ARDUINO_CORE_PATCH` macros.
Additionally, the helper macros `GET_VERSION_INT(major, minor, patch)` and `ARDUINO_CORE_VERSION_INT` are available in `core_util.h`.