### PR TITLE
Call `core_hook_usart_rx_irq` with RX DMA enabled

### DIFF
--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -167,6 +167,31 @@ public:
     }
 
     /**
+     * @brief get the last n elements that were written to the buffer
+     * @param out_elements the array to write the elements to. must be at least n elements long
+     * @param count the maximum number of elements to get
+     * @return the number of elements written to out_elements
+     * @note elements are returned in the order they were written to the buffer, so 
+     *       the first element in out_elements is most recent, and the last element is the oldest
+     * @note this is a internal operation that is made public to allow for DMA transfers into the buffer
+     */
+    size_t _get_last_written_elements(TElement *out_elements, size_t count)
+    {
+        // calculate the number of elements to get
+        // if the count is less than the number of elements in the buffer, the count remains the same
+        // if the count is greater than the capacity, the count is limited to the capacity
+        size_t elements_to_get = (count > this->capacity()) ? this->capacity() : count;
+
+        // get the last elements
+        for (size_t i = 0; i < elements_to_get; i++)
+        {
+            out_elements[i] = this->buffer[(this->_wi - 1 - i) % this->_capacity];
+        }
+
+        return elements_to_get;
+    }
+
+    /**
      * @brief get the internal data buffer
      * @note this is a internal operation that is made public to allow for DMA transfers into the buffer
      */

--- a/cores/arduino/core_hooks.h
+++ b/cores/arduino/core_hooks.h
@@ -40,6 +40,14 @@ extern "C"
      * @param data the data byte that was received
      * @param usart_channel the usart channel. (one of [1,2,3,4]; 1 => M4_USART1)
      * @note runs inside a IRQ, so keep it short and sweet
+     * @note 
+     * When using IRQ RX on the usart channel, this hook is called for each character before it is added to the RX queue. 
+     * This ensures that the hook is called for each character before it can be consumed by Usart::read.
+     *
+     * When using DMA RX, this guarantee does NOT hold. 
+     * This means that the hook may be called for characters that have already been consumed by Usart::read.
+     * 
+     * @note no gurantees are made to the timing when this hook is called.
      */
     DEF_HOOK(usart_rx_irq, uint8_t data, uint8_t usart_channel);
 

--- a/cores/arduino/drivers/mpu/mpu.cpp
+++ b/cores/arduino/drivers/mpu/mpu.cpp
@@ -40,6 +40,7 @@ inline uint8_t get_region_type(const uint32_t address)
  */
 #define MPU_CRITICAL_SECTION(fn)                                                                                       \
   {                                                                                                                    \
+    const bool irqon = !__get_PRIMASK();                                                                               \
     __disable_irq();                                                                                                   \
     uint32_t mpu_ctrl = MPU->CTRL;                                                                                     \
     MPU->CTRL = mpu_ctrl & ~MPU_CTRL_ENABLE_Msk;                                                                       \
@@ -49,7 +50,7 @@ inline uint8_t get_region_type(const uint32_t address)
     }                                                                                                                  \
     __DSB();                                                                                                           \
     MPU->CTRL = mpu_ctrl;                                                                                              \
-    __enable_irq();                                                                                                    \
+    if (irqon) __enable_irq();                                                                                         \
   }
 
 namespace mpu

--- a/cores/arduino/drivers/usart/usart_handlers.h
+++ b/cores/arduino/drivers/usart/usart_handlers.h
@@ -73,6 +73,17 @@ static void USART_rx_dma_btc_irq(uint8_t x)
     bool rxOverrun = usartx->state.rx_buffer->_update_write_index(received_bytes);
     usartx->dma.rx_buffer_last_dest_address = current_dest_address;
 
+    // get the last n elements written to the buffer and call the rx hook for each
+    uint8_t *received_chars = new uint8_t[received_bytes];
+    size_t last_written_count = usartx->state.rx_buffer->_get_last_written_elements(received_chars, received_bytes);
+    
+    // call hook in reverse order
+    for (size_t i = last_written_count; i > 0; i--)
+    {
+        core_hook_usart_rx_irq(received_chars[i - 1], x);
+    }
+    delete[] received_chars;
+
     // if the buffer was overrun, set the overrun error flag
     if (rxOverrun)
     {

--- a/cores/arduino/drivers/usart/usart_handlers.h
+++ b/cores/arduino/drivers/usart/usart_handlers.h
@@ -69,29 +69,32 @@ static void USART_rx_dma_btc_irq(uint8_t x)
         received_bytes = (buffer_len - last_dest_address) + current_dest_address;
     }
 
-    // then, update the write pointer in the rx buffer and the last destination address
-    bool rxOverrun = usartx->state.rx_buffer->_update_write_index(received_bytes);
-    usartx->dma.rx_buffer_last_dest_address = current_dest_address;
-
-    // get the last n elements written to the buffer and call the rx hook for each
-    uint8_t *received_chars = new uint8_t[received_bytes];
-    size_t last_written_count = usartx->state.rx_buffer->_get_last_written_elements(received_chars, received_bytes);
-    
-    // call hook in reverse order
-    for (size_t i = last_written_count; i > 0; i--)
+    if (received_bytes > 0)
     {
-        core_hook_usart_rx_irq(received_chars[i - 1], x);
-    }
-    delete[] received_chars;
+        // then, update the write pointer in the rx buffer and the last destination address
+        bool rxOverrun = usartx->state.rx_buffer->_update_write_index(received_bytes);
+        usartx->dma.rx_buffer_last_dest_address = current_dest_address;
 
-    // if the buffer was overrun, set the overrun error flag
-    if (rxOverrun)
-    {
-        usartx->state.rx_error = usart_receive_error_t::RxDataDropped;
-        
-        #ifdef USART_RX_ERROR_COUNTERS_ENABLE
-        usartx->state.rx_error_counters.rx_data_dropped++;
-        #endif
+        // get the last n elements written to the buffer and call the rx hook on each
+        // have to do this in reverse order because we need to get the first byte received first
+        for (size_t i = received_bytes - 1; i < received_bytes; i--)
+        {
+            uint8_t ch;
+            if (usartx->state.rx_buffer->_get_nth_push_element(i, ch))
+            {
+                core_hook_usart_rx_irq(ch, x);
+            }
+        }
+
+        // if the buffer was overrun, set the overrun error flag
+        if (rxOverrun)
+        {
+            usartx->state.rx_error = usart_receive_error_t::RxDataDropped;
+
+            #ifdef USART_RX_ERROR_COUNTERS_ENABLE
+            usartx->state.rx_error_counters.rx_data_dropped++;
+            #endif
+        }
     }
 
     // finally, clear the DMA block transfer complete flag

--- a/test/test/test_ringbuffer/ringbuffer.cpp
+++ b/test/test/test_ringbuffer/ringbuffer.cpp
@@ -173,47 +173,49 @@ TEST(RingBuffer, UpdateWriteIndex)
 TEST(RingBuffer, GetLastWrittenElements)
 {
   auto rb = new RingBuffer<uint8_t>(4);
+  uint8_t last_written;
 
-  // write 4 elements to the buffer
+  // write 3 elements to the buffer
   rb->push(1);
   rb->push(2);
   rb->push(3);
-  rb->push(4);
 
-  // the count should be 4
-  EXPECT_EQ(rb->count(), 4) << "Count should be 4 after writing 4 elements";
+  // the count should be 3
+  EXPECT_EQ(rb->count(), 3) << "Count should be 3 after writing 3 elements";
 
-  // get the last 4 written elements
-  uint8_t last_written[4];
-  size_t last_written_count = rb->_get_last_written_elements(last_written, 4);
+  // elements should be [3, 2, 1]
+  EXPECT_EQ(rb->_get_nth_push_element(0, last_written), true) << "0 pushes ago should succeed after 3 pushes";
+  EXPECT_EQ(last_written, 3) << "0 pushes ago should be 3";
 
-  // the last_written_count should be 4
-  EXPECT_EQ(last_written_count, 4) << "Last written count should be 4";
+  EXPECT_EQ(rb->_get_nth_push_element(1, last_written), true) << "1 pushes ago should succeed after 3 pushes";
+  EXPECT_EQ(last_written, 2) << "1 pushes ago should be 2";
 
-  // elements should be [4, 3, 2, 1]
-  EXPECT_EQ(last_written[0], 4) << "Last written element should be 1";
-  EXPECT_EQ(last_written[1], 3) << "Last written element should be 2";
-  EXPECT_EQ(last_written[2], 2) << "Last written element should be 3";
-  EXPECT_EQ(last_written[3], 1) << "Last written element should be 4";
+  EXPECT_EQ(rb->_get_nth_push_element(2, last_written), true) << "2 pushes ago should succeed after 3 pushes";
+  EXPECT_EQ(last_written, 1) << "2 pushes ago should be 1";
 
-  // write 2 more elements to the buffer, forcing an overrun
-  rb->push(5, /*force*/ true);
+
+  // write 3 more elements to the buffer, forcing an overrun
+  rb->push(4); // still fits
+  rb->push(5, /*force*/ true); // overruns
   rb->push(6, /*force*/ true);
 
-  // the count should still be 4
-  EXPECT_EQ(rb->count(), 4) << "Count should be 4 after writing 2 more elements with overrun";
+  // the count should be 4
+  EXPECT_EQ(rb->count(), 4) << "Count should be 4 after writing 1+2 more elements (1 normal, 2 with overrun)";
 
-  // get the last 4 written elements
-  last_written_count = rb->_get_last_written_elements(last_written, 4);
-
-  // the last_written_count should be 4 still
-  EXPECT_EQ(last_written_count, 4) << "Last written count should be 4 after overrun";
 
   // elements should be [6, 5, 4, 3]
-  EXPECT_EQ(last_written[0], 6) << "Last written element should be 3 after overrun";
-  EXPECT_EQ(last_written[1], 5) << "Last written element should be 4 after overrun";
-  EXPECT_EQ(last_written[2], 4) << "Last written element should be 5 after overrun";
-  EXPECT_EQ(last_written[3], 3) << "Last written element should be 6 after overrun";
+  EXPECT_EQ(rb->_get_nth_push_element(0, last_written), true) << "0 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 6) << "0 pushes ago should be 6";
+
+  EXPECT_EQ(rb->_get_nth_push_element(1, last_written), true) << "1 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 5) << "1 pushes ago should be 5";
+
+  EXPECT_EQ(rb->_get_nth_push_element(2, last_written), true) << "2 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 4) << "2 pushes ago should be 4";
+
+  EXPECT_EQ(rb->_get_nth_push_element(3, last_written), true) << "3 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 3) << "3 pushes ago should be 3";
+
 
   // read 2 elements from the buffer
   uint8_t dummy;
@@ -223,17 +225,23 @@ TEST(RingBuffer, GetLastWrittenElements)
   // the count should be 2
   EXPECT_EQ(rb->count(), 2) << "Count should be 2 after reading 2 elements";
 
-  // get the last 4 written elements
-  last_written_count = rb->_get_last_written_elements(last_written, 4);
- 
-  // the last_written_count should be 4 still
-  EXPECT_EQ(last_written_count, 4) << "Last written count should be 4 after reading 2 elements";
 
-  // elements should be [6, 5, 4, 3]
-  EXPECT_EQ(last_written[0], 6) << "Last written element should be 3 after reading 2 elements";
-  EXPECT_EQ(last_written[1], 5) << "Last written element should be 4 after reading 2 elements";
-  EXPECT_EQ(last_written[2], 4) << "Last written element should be 5 after reading 2 elements";
-  EXPECT_EQ(last_written[3], 3) << "Last written element should be 6 after reading 2 elements";
+  // elements should still be [6, 5, 4, 3], as reading doesn't affect what was last written
+  EXPECT_EQ(rb->_get_nth_push_element(0, last_written), true) << "0 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 6) << "0 pushes ago should be 6";
+
+  EXPECT_EQ(rb->_get_nth_push_element(1, last_written), true) << "1 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 5) << "1 pushes ago should be 5";
+
+  EXPECT_EQ(rb->_get_nth_push_element(2, last_written), true) << "2 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 4) << "2 pushes ago should be 4";
+
+  EXPECT_EQ(rb->_get_nth_push_element(3, last_written), true) << "3 pushes ago should succeed after 4 pushes";
+  EXPECT_EQ(last_written, 3) << "3 pushes ago should be 3";
+
+
+  // 5 pushes ago in a 4-element buffer doesn't exist
+  EXPECT_EQ(rb->_get_nth_push_element(4, last_written), false) << "4 pushes ago should fail for buffer of size 4";
 
   delete rb;
 }


### PR DESCRIPTION
updates the `USART_rx_dma_btc_irq` to call `core_hook_usart_rx_irq` for all characters received since the last handler invocation.

this is done using an added function `RingBuffer::_get_nth_push_element` which is used to get `wi - n`th element, so the element that was `push`-ed `n` `push`-calls ago. 


due to the implementation, the `core_hook_usart_rx_irq` hook can no longer gurantee that  it is only invoked for un-`read` elements. 
this means that the hook may be called for elements that were already removed from the RX buffer by reading. 
