### PR TITLE
Semihosting API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ for documentation on configuration and non-standard features, see following docu
 - [Assert Mechanism](./docs/ASSERT.md)
 - [Panic Mechanism](./docs/PANIC.md)
 - [Fault Handler](./docs/FAULT_HANDLER.md)
-
+- [Semihosting](./docs/SEMIHOSTING.md)
 
 ## License
 

--- a/cores/arduino/drivers/semihosting/host_printf_redir.cpp
+++ b/cores/arduino/drivers/semihosting/host_printf_redir.cpp
@@ -14,7 +14,12 @@
  * @return number of bytes written
  */
 extern "C" int _write(int file, char *ptr, int len) {
-  return sh_write(SH_STDOUT_FILENO, ptr, len);
+  if (!sh_is_debugger_attached()) {
+    return len;
+  }
+
+  const size_t r = sh_write(SH_STDOUT_FILENO, ptr, len);
+  return len - r;
 }
 
 /**

--- a/cores/arduino/drivers/semihosting/host_printf_redir.cpp
+++ b/cores/arduino/drivers/semihosting/host_printf_redir.cpp
@@ -1,0 +1,29 @@
+#if REDIRECT_PRINTF_TO_DEBUGGER
+
+#ifndef __GNUC__
+  #error "only GCC is supported"
+#endif
+
+#include "semihosting.h"
+
+/**
+ * @brief implementation of _write that redirects everything to the debugger console via semihosting
+ * @param file file descriptor. don't care
+ * @param ptr pointer to the data to write
+ * @param len length of the data to write
+ * @return number of bytes written
+ */
+extern "C" int _write(int file, char *ptr, int len) {
+  return sh_write(SH_STDOUT_FILENO, ptr, len);
+}
+
+/**
+ * @brief implementation of _isatty that always returns 1
+ * @param file file descriptor. don't care
+ * @return everything is a tty. there are no files to be had
+ */
+extern "C" int _isatty(int file) {
+  return 1;
+}
+
+#endif // REDIRECT_PRINTF_TO_DEBUGGER

--- a/cores/arduino/drivers/semihosting/semihosting.h
+++ b/cores/arduino/drivers/semihosting/semihosting.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <cstring>
+#include <hc32_ddl.h>
 
 
 #define SH_SYS_OPEN 0x01
@@ -33,6 +34,23 @@
 #define SH_OPEN_AP 10  // "a+"
 #define SH_OPEN_APB 11 // "a+b"
 
+/**
+ * @brief Check if semihosting is available (=a debugger is attached)
+ * @returns true if semihosting is available, false otherwise.
+ * 
+ * @note
+ * Since there isn't actually a direct way to check if semihosting is available,
+ * this function will instead check if a debugger is attached.
+ * While this may cause false positives, it at least stops the cpu from halting 
+ * due to the bkpt instruction used in semihosting calls.
+ * 
+ * @note 
+ * see https://developer.arm.com/documentation/ddi0403/d/Debug-Architecture/ARMv7-M-Debug/Debug-register-support-in-the-SCS/Debug-Halting-Control-and-Status-Register--DHCSR?lang=en
+ */
+inline bool sh_is_debugger_attached()
+{
+    return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+}
 
 /**
  * @brief Send a semihosting command to the debugger.

--- a/cores/arduino/drivers/semihosting/semihosting.h
+++ b/cores/arduino/drivers/semihosting/semihosting.h
@@ -1,0 +1,128 @@
+/**
+ * Semihosting driver for HC32F460. 
+ * Implements a subset of the ARM semihosting calls.
+ * based on https://electronics.stackexchange.com/a/149403
+ */
+
+#ifndef SEMIHOSTING_H
+#define SEMIHOSTING_H
+
+#include <stdint.h>
+#include <cstring>
+
+
+#define SH_SYS_OPEN 0x01
+#define SH_SYS_CLOSE 0x02
+#define SH_SYS_WRITEC 0x03
+#define SH_SYS_WRITE0 0x04
+#define SH_SYS_WRITE 0x05
+
+#define SH_STDOUT_FILENO 1
+#define SH_STDERR_FILENO 2
+
+#define SH_OPEN_R 0    // "r"
+#define SH_OPEN_RB 1   // "rb"
+#define SH_OPEN_RP 2   // "r+"
+#define SH_OPEN_RPB 3  // "r+b"
+#define SH_OPEN_W 4    // "w"
+#define SH_OPEN_WB 5   // "wb"
+#define SH_OPEN_WP 6   // "w+"
+#define SH_OPEN_WPB 7  // "w+b"
+#define SH_OPEN_A 8    // "a"
+#define SH_OPEN_AB 9   // "ab"
+#define SH_OPEN_AP 10  // "a+"
+#define SH_OPEN_APB 11 // "a+b"
+
+
+/**
+ * @brief Send a semihosting command to the debugger.
+ * @param command The command to send. One of SH_SYS_*.
+ * @param param The parameter to pass to the command. depends on the command.
+ */
+inline int sh_syscall(const int command, const void *param)
+{
+    int result;
+    asm volatile(
+        "mov r0, %[cmd];"
+        "mov r1, %[param];"
+        "bkpt #0xAB;"
+        "mov %[result], r0;"
+            : [result] "=r" (result)
+            : [cmd] "r" (command), 
+              [param] "r" (param)
+            : "r0", "r1", "memory"
+    );
+    return result;
+}
+
+/**
+ * @brief open a file on the host
+ * @param filename The name of the file to open.
+ * @param mode The mode the file is opened in. corosponds to ISO C fopen modes.
+ * @returns a file descriptor on success, or -1 on failure.
+ * 
+ * @note see https://developer.arm.com/documentation/dui0471/i/semihosting/sys-open--0x01-
+ */
+inline int sh_open(const char *filename, const int mode)
+{
+    const uint32_t filename_ptr = reinterpret_cast<uint32_t>(filename);
+    const size_t filename_len = strlen(filename);
+    const uint32_t param[3] = { filename_ptr, static_cast<uint32_t>(mode), filename_len };
+
+    return sh_syscall(SH_SYS_OPEN, param);
+}
+
+/**
+ * @brief close a file descriptor on the host
+ * @param fd The file descriptor to close.
+ * @returns 0 on success, or -1 on failure.
+ * 
+ * @note see https://developer.arm.com/documentation/dui0471/i/semihosting/sys-close--0x02-
+ */
+inline int sh_close(const int fd)
+{
+    const uint32_t param[1] = { static_cast<uint32_t>(fd) };
+
+    return sh_syscall(SH_SYS_CLOSE, param);
+}
+
+/**
+ * @brief write to a file descriptor on the host
+ * @param fd The file descriptor to write to. may be SH_STDOUT_FILENO or SH_STDERR_FILENO.
+ * @param buf The buffer to write from.
+ * @param len The length of the buffer.
+ * @returns 0 on success, or the number of bytes that were not written.
+ * 
+ * @note see https://developer.arm.com/documentation/dui0471/i/semihosting/sys-write--0x05-
+ */
+inline size_t sh_write(const int fd, const void *buf, const size_t len)
+{
+    const uint32_t buf_ptr = reinterpret_cast<uint32_t>(buf);
+    const uint32_t param[3] = { static_cast<uint32_t>(fd), buf_ptr, len };
+
+    return sh_syscall(SH_SYS_WRITE, param);
+}
+
+/**
+ * @brief write a character to the host
+ * @param c The character to write.
+ * 
+ * @note see https://developer.arm.com/documentation/dui0471/i/semihosting/sys-writec--0x03-
+ */
+inline void sh_writec(char c)
+{
+    sh_syscall(SH_SYS_WRITEC, &c);
+}
+
+/**
+ * @brief write a null-terminated string to the host
+ * @param str The string to write.
+ * 
+ * @note see https://developer.arm.com/documentation/dui0471/i/semihosting/sys-write0--0x04-
+ */
+inline void sh_write0(const char *str)
+{
+    sh_syscall(SH_SYS_WRITE0, str);
+}
+
+#endif // SEMIHOSTING_H

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -42,8 +42,9 @@ the following options configure the debugging behavior of the core.
 | `PANIC_USART<n>_TX_PIN`       | panic         | set the gpio pin that is used to transmit panic messages. `[n]` can be any value in [1,2,3,4]         | disabled      |
 | `CORE_DISABLE_FAULT_HANDLER`  | fault_handler | disable the core-internal fault handler. this is only recommended if you have your own fault handler. | disabled      |
 | `HARDFAULT_EXCLUDE_CFSR_INFO` | fault_handler | exclude CFSR flag parsing from fault output, reducing flash usage.                                    | disabled      |
+| `REDIRECT_PRINTF_TO_DEBUGGER` | core_debug    | redirect `printf()` calls to the debugger's console via semihosting. Set to `1` to enable             | disabled      |
 
-see the Documentation for the [`panic`](./PANIC.md) and [`fault_handler`](./FAULT_HANDLER.md) modules for more information.
+see the Documentation for the [`panic`](./PANIC.md), [`fault_handler`](./FAULT_HANDLER.md) and [`semihosting`](./SEMIHOSTING.md) modules for more information.
 
 
 ## Miscellanous Options

--- a/docs/SEMIHOSTING.md
+++ b/docs/SEMIHOSTING.md
@@ -19,9 +19,13 @@ for usage examples, refer to the example given in `examples/semihosting`.
 
 
 > [!WARNING]
-> without a debugger attached, calling any of the semihosting functions may result in the target stopping execution.
-
+> without a debugger attached, calling any of the semihosting functions may result in the target stopping execution.   
+> you can also check if a debugger is attached using the `sh_is_debugger_attached` function.
 
 ## printf redirection
 
 by defining `REDIRECT_PRINTF_TO_DEBUGGER=1` during build, the `printf` function will be redirected to the debugger console using semihosting.
+
+> [!TIP]
+> printf redirection will automatically check if a debugger is attached before redirecting output. 
+> this means that you can use `printf` in your code without worrying about the target stopping execution when no debugger is attached.

--- a/docs/SEMIHOSTING.md
+++ b/docs/SEMIHOSTING.md
@@ -1,10 +1,50 @@
 # Semihosting Driver
 
-the arduino core includes a driver for Semihosting support.
+the arduino core includes a driver for [Semihosting](https://pyocd.io/docs/semihosting.html) support.
 Semihosting allows a debugging target (the HC32F460 in this case) to call system calls on the debugging host machine, e.g. writing to the debuggers console.
 
 > [!TIP]
 > Semihosting is only available when the target is connected to a debugger.
+
+> [!TIP]
+> Semihosting only works with a supported debugger and semihosting enabled.
+
+
+## Usage
+
+semihosting is by default disabled in pyOCD, so if you want to use it you'll need to enable it. 
+you can do this by either running 'monitor arm semihosting enable' in the debug console, or alternatively by adding the same command to your `.platformio.ini` file:
+
+```ini
+# ...
+debug_extra_cmds =
+    monitor arm semihosting enable
+```
+
+> [!TIP]
+> it seems like single-stepping over functions containing semihosting calls don't work correctly.   
+> the target will stop execution at the semihosting call, but gdb will not pick this up.
+> thus, the debugging sessions seems stuck.
+> To work around this, manually pause the target and continue again (make sure to set a breakpoint where you want to end up after continuing).
+
+
+### Console Output
+
+after enabling semihosting, you can connect to the telnet server (normally on port 4444, but refer to debug console) using a telnet client like puTTY.
+
+> [!TIP]
+> when using puTTY, make sure to enable the "Implicit CR in every LF" option in the terminal settings, as output is otherwise not displayed correctly.
+
+
+there is also some way to redirect the semihosting output to the debug console, but this doesn't seem to work at the moment.
+commands for this should normally be `monitor set option semihost_console_type=console` or `monitor set option semihost_console_type=telnet`, and can be checked with `monitor show option semihost_console_type`.
+
+
+### File I/O
+
+the semihosting driver supports writing to files on the host machine.
+relative paths are resolved relative to the pyOCD package directory, which is usually located in `~/.platformio/packages/tool-pyocd/` or `C:/Users/<username>/.platformio/packages/tool-pyocd/`.
+this sadly cannot be changed at the moment.
 
 
 ## C API

--- a/docs/SEMIHOSTING.md
+++ b/docs/SEMIHOSTING.md
@@ -1,0 +1,27 @@
+# Semihosting Driver
+
+the arduino core includes a driver for Semihosting support.
+Semihosting allows a debugging target (the HC32F460 in this case) to call system calls on the debugging host machine, e.g. writing to the debuggers console.
+
+> [!TIP]
+> Semihosting is only available when the target is connected to a debugger.
+
+
+## C API
+
+the semihosting driver is exposed through the `semihosting.h` header file.
+this header provides both a generic `sh_syscall` function for directly calling semihosting system calls, as well as wrapper functions for commonly used operations.
+
+generally, the functions are fairly similar to linux system calls, but with a `sh_` prefix.
+
+
+for usage examples, refer to the example given in `examples/semihosting`.
+
+
+> [!WARNING]
+> without a debugger attached, calling any of the semihosting functions may result in the target stopping execution.
+
+
+## printf redirection
+
+by defining `REDIRECT_PRINTF_TO_DEBUGGER=1` during build, the `printf` function will be redirected to the debugger console using semihosting.

--- a/examples/semihosting/.gitignore
+++ b/examples/semihosting/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/semihosting/platformio.ini
+++ b/examples/semihosting/platformio.ini
@@ -5,6 +5,14 @@ board = generic_hc32f460
 build_flags = 
     -D REDIRECT_PRINTF_TO_DEBUGGER=1
 
+build_type = debug
+upload_protocol = cmsis-dap
+debug_tool = cmsis-dap
+
+# so you don't have to manually enable semihosting every time you start a debug session
+debug_extra_cmds =
+    monitor arm semihosting enable
+
 [env:default]
 
 # required only for CI

--- a/examples/semihosting/platformio.ini
+++ b/examples/semihosting/platformio.ini
@@ -1,0 +1,15 @@
+[env]
+platform = https://github.com/shadow578/platform-hc32f46x/archive/1.1.1.zip
+framework = arduino
+board = generic_hc32f460
+build_flags = 
+    -D REDIRECT_PRINTF_TO_DEBUGGER=1
+
+[env:default]
+
+# required only for CI
+[env:ci]
+# override theframework-arduino-hc32f46x package with the local one
+board_build.arduino_package_dir = ../../
+extra_scripts = 
+    pre:../../tools/ci/patch_get_package_dir.py

--- a/examples/semihosting/platformio.ini
+++ b/examples/semihosting/platformio.ini
@@ -5,6 +5,7 @@ board = generic_hc32f460
 build_flags = 
     -D REDIRECT_PRINTF_TO_DEBUGGER=1
 
+[env:default]
 build_type = debug
 upload_protocol = cmsis-dap
 debug_tool = cmsis-dap
@@ -12,8 +13,6 @@ debug_tool = cmsis-dap
 # so you don't have to manually enable semihosting every time you start a debug session
 debug_extra_cmds =
     monitor arm semihosting enable
-
-[env:default]
 
 # required only for CI
 [env:ci]

--- a/examples/semihosting/src/main.cpp
+++ b/examples/semihosting/src/main.cpp
@@ -11,6 +11,10 @@
 
 void setup()
 {
+  // wait for a debugger to attach
+  while(!sh_is_debugger_attached())
+    delay(100);
+
   // write to the hosts console
   sh_writec('H'); // ~= putchar('H');
   sh_write0("ello, world!\n"); // ~= puts("ello, world!\n");

--- a/examples/semihosting/src/main.cpp
+++ b/examples/semihosting/src/main.cpp
@@ -2,8 +2,8 @@
  * Semihosting driver example.
  * 
  * For any of this do do anything, you must have run this in a debugging session.
- * Once connected, the debugger should break automatically.
- * From there, open the "Debug Console" and run: "monitor arm semihosting enable" to enable semihosting support.
+ * - Output is written to telnet, the port is printed in the debug console (normally it is 4444).
+ * - relative file paths are resolved relative to the pyOCD package directory (~/.platformio/packages/tool-pyocd).
  */
 
 #include <Arduino.h>

--- a/examples/semihosting/src/main.cpp
+++ b/examples/semihosting/src/main.cpp
@@ -1,0 +1,33 @@
+/**
+ * Semihosting driver example.
+ * 
+ * For any of this do do anything, you must have run this in a debugging session.
+ * Once connected, the debugger should break automatically.
+ * From there, open the "Debug Console" and run: "monitor arm semihosting enable" to enable semihosting support.
+ */
+
+#include <Arduino.h>
+#include <drivers/semihosting/semihosting.h>
+
+void setup()
+{
+  // write to the hosts console
+  sh_writec('H'); // ~= putchar('H');
+  sh_write0("ello, world!\n"); // ~= puts("ello, world!\n");
+
+  sh_write(SH_STDOUT_FILENO, "Hello, stdout!\n", 15); // ~= write(STDOUT_FILENO, "Hello, stdout!\n", 15);
+  sh_write(SH_STDERR_FILENO, "Hello, stderr!\n", 15); // ~= write(STDERR_FILENO, "Hello, stderr!\n", 15);
+
+  // with REDIRECT_PRINTF_TO_DEBUGGER=1, printf also writes to the host
+  printf("Hello, printf!\n");
+
+  // open a file on the host and write to it
+  const int fd = sh_open("test.txt", SH_OPEN_A); // ~= fopen("test.txt", "a");
+  if (fd != -1)
+  {
+    sh_write(fd, "Hello, file!\n", 13); // ~= write(fd, "Hello, file!\n", 13);
+    sh_close(fd); // ~= close(fd);
+  }
+}
+
+void loop() {}


### PR DESCRIPTION
This PR adds a driver for semihosting, allowing the use of some semihosting apis.
additionally, a option to redirect `printf` to semihosting is added.